### PR TITLE
fix(mcptoolprovider): fixed invalid reference to self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.1] - 2025-05-08
+
+### Fixed
+- Invalid reference to `self` in `MCPToolProvider`'s `call_too()` method. 
+
 ## [0.4.0] - 2025-05-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "treelang"
-version = "0.4.0"
+version = "0.4.1"
 description = "LLM function calling on steroids using Abstract Syntax Trees."
 authors = [
     {name = "csolar",email = "cristiano.solarino@brightminded.com"}

--- a/treelang/ai/provider.py
+++ b/treelang/ai/provider.py
@@ -47,7 +47,7 @@ class MCPToolProvider(ToolProvider):
         if isinstance(output.content, list) and len(output.content):
             if output.content[0].text.startswith("Error"):
                 raise RuntimeError(
-                    f"Error calling tool {self.name}: {output.content[0].text}"
+                    f"Error calling tool {name}: {output.content[0].text}"
                 )
             # return the result attempting to transform it into its appropriate type
             content = (


### PR DESCRIPTION
Removed invalid reference to self in `MCPToolProvider`.