### PR TITLE
Feature/conditional tree node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.5.0] - 2025-05-11
+## [0.5.0] - 2025-05-13
 
 ### Added
 - `TreeConditional` node for support of `if-then-else` conditionals in `treelang`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.5.0] - 2025-05-11
+
+### Added
+- `TreeConditional` node for support of `if-then-else` conditionals in `treelang`.
+
+### Changed
+- Added conditionals support in `AST` parsing, evaluating, visiting and representing (`repr()`)
+- Added conditional node tests.
+- Added conditional example to `Evaluator`.
+- Added example of query with conditional in `calculator.ipynb` cookbook.
+- Added `greater_than` tool in `calculator.py`.
+
 ## [0.4.1] - 2025-05-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Added example of query with conditional in `calculator.ipynb` cookbook.
 - Added `greater_than` tool in `calculator.py`.
 
+### Fixed
+- Parameter binding for tool creation when multiple arguments have the same name in `AST.tool()`.
+
 ## [0.4.1] - 2025-05-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Why `treelang`
 
-- **Complex worflows/function nesting**: Primarily `treelang` was created as a practical way to support arbitrarily complex function composition, where the answer to a question may involve multiple steps each with its own multiple dependencies.
+- **Complex worflows**: Primarily `treelang` was created as a practical way to support arbitrarily complex function composition and conditionals, where the answer to a question may involve multiple steps each with its own multiple dependencies. 
 
 - **Cost-Saving and Green**: With `treelang` you avoid the typical function-calling loop whereby the LLM outputs a function call, your program evaluates it and returns the result back to the LLM for this cycle to repeat until the final result is computed. `treelang` generates the AST for the full solution using a single call to the underlying LLM!
 

--- a/cookbook/calculator.ipynb
+++ b/cookbook/calculator.ipynb
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,15 @@
     "            question = f\"can you please calculate {expressions[1]}?\"\n",
     "            response = await arborist.eval(question, EvalType.WALK)\n",
     "            print(f\"\\nQUESTION: {question}\")\n",
-    "            print(f\"\\nANSWER: {response.explain()}\")"
+    "            print(f\"\\nANSWER: {response.explain()}\")\n",
+    "            # let's see how conditionals work\n",
+    "            question = f\"can you please calculate {expressions[2]}? but if the result is greater than 100, return 100\"\n",
+    "            response = await arborist.eval(question, EvalType.TREE)\n",
+    "            print(f\"\\nQUESTION: {question}\")\n",
+    "            print(f\"\\nTREE: {AST.repr(response.content)}\")\n",
+    "            # let's evaluate the conditional\n",
+    "            response = await arborist.eval(question)\n",
+    "            print(f\"\\nEVALUATED ANSWER: {response.content}\")"
    ]
   },
   {
@@ -116,16 +124,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<Task pending name='Task-5' coro=<main() running at /tmp/ipykernel_31603/4107820128.py:9>>"
+       "<Task pending name='Task-99' coro=<main() running at /tmp/ipykernel_27379/2358096826.py:9>>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -143,33 +151,33 @@
       "\n",
       "QUESTION: can you please calculate ( 15 / 3 ) + ( 2^4 - 6 ) * ( 9 - 5 )?\n",
       "\n",
-      "ANSWER: Alright, let's break this down in a clear and logical way!\n",
+      "ANSWER: Sure, let's break this down!\n",
       "\n",
-      "The question asks us to calculate the result of this expression:  \n",
-      "**(15 ÷ 3) + (2⁴ - 6) × (9 - 5)**\n",
+      "The user wanted to calculate this expression:  \n",
+      "(15 ÷ 3) + ((2⁴ - 6) × (9 - 5))\n",
       "\n",
-      "Here's how it works step-by-step:\n",
+      "Here’s how it was evaluated step-by-step:  \n",
       "\n",
-      "1. **First part: (15 ÷ 3):**  \n",
-      "   Divide 15 by 3, which gives you **5**.\n",
+      "1. **Handle the parentheses first, working inside out**:\n",
+      "   - **(15 ÷ 3)** equals 5.\n",
+      "   - **(2⁴ - 6)** means 2 to the power of 4 (which is 16), minus 6. So, that's **16 - 6 = 10**.  \n",
+      "   - **(9 - 5)** equals 4.\n",
       "\n",
-      "2. **Second part: (2⁴ - 6):**  \n",
-      "   The \"2⁴\" means 2 raised to the power of 4, or 2 × 2 × 2 × 2, which equals **16**.  \n",
-      "   Subtract 6 from 16, and you get **10**.\n",
+      "2. **Now resolve the multiplication and addition**:\n",
+      "   - From the above, **(10 × 4)** equals 40.\n",
+      "   - Finally, **5 + 40** equals **45**.\n",
       "\n",
-      "3. **Third part: (9 - 5):**  \n",
-      "   Subtract 5 from 9, and you get **4**.\n",
+      "So, the result of the entire calculation is **45**.\n",
       "\n",
-      "4. **Final step: Combine it all!**  \n",
-      "   Now put everything together according to the original equation:  \n",
-      "   **5 + (10 × 4)**  \n",
-      "   First, multiply 10 by 4, which equals **40**.  \n",
-      "   Then add the first part (5), so **5 + 40 = 45**.\n",
+      "The provided JSON confirms this result with the value `'data': 45.0`.\n",
       "\n",
-      "### Final Answer:  \n",
-      "The result of the expression is **45.0** (as reflected in the JSON data).  \n",
+      "In short, the answer to the question is **45**! 😊 Let me know if you'd like to go over any specific part in more detail.\n",
       "\n",
-      "This JSON simply confirms that the calculated value for the question is correct—it’s **45.0**, no surprises there! Let me know if you'd like me to walk through more calculations like this. 😊\n"
+      "QUESTION: can you please calculate ( 50 - 8 ) / 2 + sqrt( 64 ) * 3^2? but if the result is greater than 100, return 100\n",
+      "\n",
+      "TREE: {\"conditional_1\": {\"greater_than_1\": {\"add_1\": {\"divide_1\": {\"subtract_1\": {\"a\": [50], \"b\": [8]}, \"b\": [2]}, \"multiply_1\": {\"sqrt_1\": {\"a\": [64]}, \"power_1\": {\"a\": [3], \"b\": [2]}}}, \"b\": [100]}, \"result\": [100], \"add_2\": {\"divide_2\": {\"subtract_2\": {\"a\": [50], \"b\": [8]}, \"b\": [2]}, \"multiply_2\": {\"sqrt_2\": {\"a\": [64]}, \"power_2\": {\"a\": [3], \"b\": [2]}}}}}\n",
+      "\n",
+      "EVALUATED ANSWER: 93.0\n"
      ]
     }
    ],

--- a/cookbook/calculator.py
+++ b/cookbook/calculator.py
@@ -32,6 +32,11 @@ def power(a: float, b: float) -> float:
 
 
 @mcp.tool()
+def greater_than(a: float, b: float) -> bool:
+    return a > b
+
+
+@mcp.tool()
 def sqrt(a: float) -> float:
     a = float(a)
 

--- a/evaluation/data/nested.py
+++ b/evaluation/data/nested.py
@@ -104,7 +104,7 @@ questions = [
     "What's the current exchange rate from USD to the currency used in Japan?",
     "What's the GDP per capita of the country whose national animal is the kangaroo?",
     "If the GDP of Canada is negative, give me its GDP per capita otherwise return its GDP.",
-    "What's the average annual rainfall in the capital city of the country that produces the most coffee in the world?"
+    "What's the average annual rainfall in the capital city of the country that produces the most coffee in the world?",
 ]
 
 
@@ -132,7 +132,10 @@ answers = [
     },
     {
         "conditional_1": {
-            "greater_than_1": {"get_gdp_1": {"country": ["Canada"]}, "threshold": ["0"]},
+            "greater_than_1": {
+                "get_gdp_1": {"country": ["Canada"]},
+                "threshold": ["0"],
+            },
             "get_gdp_2": {"country": ["Canada"]},
             "calculate_per_capita_1": {
                 "get_gdp_3": {"country": ["Canada"]},
@@ -146,5 +149,5 @@ answers = [
                 "get_capital_city_1": {"get_top_producer_1": {"product": ["coffee"]}}
             }
         }
-    }
+    },
 ]

--- a/evaluation/data/nested.py
+++ b/evaluation/data/nested.py
@@ -43,7 +43,7 @@ def get_annual_rainfall(city):
     pass
 
 
-def calculate_average(rainfall_data):
+def average(rainfall_data):
     """Calculate the average from a list of rainfall data."""
     pass
 
@@ -73,6 +73,11 @@ def get_author(book_title):
     pass
 
 
+def greater_than(value, threshold):
+    """Check if a value is greater than a given threshold."""
+    pass
+
+
 tools = [
     get_top_producer,
     get_capital_city,
@@ -83,12 +88,13 @@ tools = [
     get_exchange_rate,
     get_country_currency,
     get_annual_rainfall,
-    calculate_average,
+    average,
     get_country_by_national_animal,
     get_gdp,
     calculate_per_capita,
     count_books,
     get_author,
+    greater_than,
 ]
 
 questions = [
@@ -96,8 +102,9 @@ questions = [
     "How many books has the author of '1984' written?",
     "What's the population of the largest city in Canada?",
     "What's the current exchange rate from USD to the currency used in Japan?",
-    "What's the average annual rainfall in the capital city of the country that produces the most coffee in the world?",
     "What's the GDP per capita of the country whose national animal is the kangaroo?",
+    "If the GDP of Canada is negative, give me its GDP per capita otherwise return its GDP.",
+    "What's the average annual rainfall in the capital city of the country that produces the most coffee in the world?"
 ]
 
 
@@ -116,13 +123,6 @@ answers = [
         }
     },
     {
-        "calculate_average_1": {
-            "get_annual_rainfall_1": {
-                "get_capital_city_1": {"get_top_producer_1": {"product": ["coffee"]}}
-            }
-        }
-    },
-    {
         "calculate_per_capita_1": {
             "get_gdp_1": {"get_country_by_national_animal_1": {"animal": ["kangaroo"]}},
             "get_country_population_1": {
@@ -130,4 +130,21 @@ answers = [
             },
         }
     },
+    {
+        "conditional_1": {
+            "greater_than_1": {"get_gdp_1": {"country": ["Canada"]}, "threshold": ["0"]},
+            "get_gdp_2": {"country": ["Canada"]},
+            "calculate_per_capita_1": {
+                "get_gdp_3": {"country": ["Canada"]},
+                "get_country_population_1": {"country": ["Canada"]},
+            },
+        }
+    },
+    {
+        "average_1": {
+            "get_annual_rainfall_1": {
+                "get_capital_city_1": {"get_top_producer_1": {"product": ["coffee"]}}
+            }
+        }
+    }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "treelang"
-version = "0.4.1"
+version = "0.5.0"
 description = "LLM function calling on steroids using Abstract Syntax Trees."
 authors = [
     {name = "csolar",email = "cristiano.solarino@brightminded.com"}

--- a/tests/trees/test_tree.py
+++ b/tests/trees/test_tree.py
@@ -5,6 +5,7 @@ from treelang.ai.provider import ToolOutput, ToolProvider
 import mcp.types as types
 from treelang.trees.tree import (
     AST,
+    TreeConditional,
     TreeNode,
     TreeProgram,
     TreeFunction,
@@ -78,6 +79,48 @@ class TestTreeValue(unittest.TestCase):
         self.assertEqual(result, 42)
 
 
+class TestTreeConditional(unittest.TestCase):
+    def test_tree_conditional_init(self):
+        condition = TreeValue("condition", True)
+        true_branch = TreeValue("true_branch", "True Result")
+        false_branch = TreeValue("false_branch", "False Result")
+        conditional = TreeConditional(condition, true_branch, false_branch)
+
+        self.assertEqual(conditional.type, "conditional")
+        self.assertEqual(conditional.condition, condition)
+        self.assertEqual(conditional.true_branch, true_branch)
+        self.assertEqual(conditional.false_branch, false_branch)
+
+    def test_tree_conditional_eval_true_branch(self):
+        condition = TreeValue("condition", True)
+        true_branch = TreeValue("true_branch", "True Result")
+        false_branch = TreeValue("false_branch", "False Result")
+        conditional = TreeConditional(condition, true_branch, false_branch)
+
+        provider = AsyncMock(spec=ToolProvider)
+        result = asyncio.run(conditional.eval(provider))
+        self.assertEqual(result, "True Result")
+
+    def test_tree_conditional_eval_false_branch(self):
+        condition = TreeValue("condition", False)
+        true_branch = TreeValue("true_branch", "True Result")
+        false_branch = TreeValue("false_branch", "False Result")
+        conditional = TreeConditional(condition, true_branch, false_branch)
+
+        provider = AsyncMock(spec=ToolProvider)
+        result = asyncio.run(conditional.eval(provider))
+        self.assertEqual(result, "False Result")
+
+    def test_tree_conditional_eval_no_false_branch(self):
+        condition = TreeValue("condition", False)
+        true_branch = TreeValue("true_branch", "True Result")
+        conditional = TreeConditional(condition, true_branch)
+
+        provider = AsyncMock(spec=ToolProvider)
+        result = asyncio.run(conditional.eval(provider))
+        self.assertIsNone(result)
+
+
 class TestAST(unittest.TestCase):
     def setUp(self):
         self.ast = [
@@ -113,6 +156,30 @@ class TestAST(unittest.TestCase):
         result = AST.parse(ast_dict)
         self.assertIsInstance(result, TreeFunction)
         self.assertEqual(result.name, "test_function")
+
+    def test_parse_conditional(self):
+        ast_dict = {
+            "type": "conditional",
+            "condition": {"type": "value", "name": "condition", "value": True},
+            "true_branch": {
+                "type": "value",
+                "name": "true_branch",
+                "value": "True Result",
+            },
+            "false_branch": {
+                "type": "value",
+                "name": "false_branch",
+                "value": "False Result",
+            },
+        }
+        result = AST.parse(ast_dict)
+        self.assertIsInstance(result, TreeConditional)
+        self.assertIsInstance(result.condition, TreeValue)
+        self.assertIsInstance(result.true_branch, TreeValue)
+        self.assertIsInstance(result.false_branch, TreeValue)
+        self.assertEqual(result.condition.value, True)
+        self.assertEqual(result.true_branch.value, "True Result")
+        self.assertEqual(result.false_branch.value, "False Result")
 
     def test_parse_value(self):
         ast_dict = {"type": "value", "name": "test_value", "value": 42}
@@ -179,11 +246,101 @@ class TestAST(unittest.TestCase):
             self.assertIsNotNone(result)
             self.assertEqual(int(result), (12 * 6) + 4)
 
+    def test_eval_with_conditional(self):
+        class MockToolProvider(ToolProvider):
+            async def call_tool(self, name, arguments):
+                if name == "isPositive":
+                    return ToolOutput(content=arguments["x"] > 0)
+                elif name == "print":
+                    return ToolOutput(content=f"Message: {arguments['message']}")
+                raise ValueError(f"Unknown tool: {name}")
+
+            async def list_tools():
+                return AsyncMock(
+                    tools=[
+                        {
+                            "name": "isPositive",
+                            "description": "Checks if a number is positive",
+                            "properties": {"x": {}},
+                        },
+                        {
+                            "name": "print",
+                            "description": "Prints a message",
+                            "properties": {"message": {}},
+                        },
+                    ]
+                )
+
+            async def get_tool_definition(self, name):
+                if name == "isPositive":
+                    return {
+                        "name": "isPositive",
+                        "description": "Checks if a number is positive",
+                        "properties": {"x": {}},
+                    }
+                elif name == "print":
+                    return {
+                        "name": "print",
+                        "description": "Prints a message",
+                        "properties": {"message": {}},
+                    }
+                else:
+                    raise ValueError(f"Tool {name} not found")
+
+        ast_dict = {
+            "type": "program",
+            "body": [
+                {
+                    "type": "conditional",
+                    "condition": {
+                        "type": "function",
+                        "name": "isPositive",
+                        "params": [{"type": "value", "name": "x", "value": -5}],
+                    },
+                    "true_branch": {
+                        "type": "function",
+                        "name": "print",
+                        "params": [
+                            {"type": "value", "name": "message", "value": "Positive"}
+                        ],
+                    },
+                    "false_branch": {
+                        "type": "function",
+                        "name": "print",
+                        "params": [
+                            {"type": "value", "name": "message", "value": "Negative"}
+                        ],
+                    },
+                }
+            ],
+        }
+
+        provider = MockToolProvider()
+        program = AST.parse(ast_dict)
+        result = asyncio.run(AST.eval(program, provider))
+        self.assertEqual(result, "Message: Negative")
+
     def test_visit(self):
         node = TreeNode("test")
         op = Mock()
         AST.visit(node, op)
         op.assert_called_once_with(node)
+
+    def test_visit_with_conditional(self):
+        condition = TreeValue("condition", True)
+        true_branch = TreeValue("true_branch", "True Result")
+        false_branch = TreeValue("false_branch", "False Result")
+        conditional = TreeConditional(condition, true_branch, false_branch)
+
+        op = Mock()
+        AST.visit(conditional, op)
+
+        # Assert that the visitor function was called for the conditional node and its children
+        op.assert_any_call(conditional)
+        op.assert_any_call(condition)
+        op.assert_any_call(true_branch)
+        op.assert_any_call(false_branch)
+        self.assertEqual(op.call_count, 4)  # Ensure all nodes were visited
 
     def test_repr(self):
         ast = TreeProgram(
@@ -194,6 +351,32 @@ class TestAST(unittest.TestCase):
         )
         result = AST.repr(ast)
         self.assertEqual(result, '{"foo_1": {}, "z": [10]}')
+
+    def test_repr_with_conditional(self):
+        ast = TreeProgram(
+            body=[
+                TreeConditional(
+                    condition=TreeFunction(
+                        name="isPositive", params=[TreeValue(name="x", value=-5)]
+                    ),
+                    true_branch=TreeFunction(
+                        name="print",
+                        params=[TreeValue(name="message", value="Positive")],
+                    ),
+                    false_branch=TreeFunction(
+                        name="print",
+                        params=[TreeValue(name="message", value="Negative")],
+                    ),
+                )
+            ]
+        )
+        result = AST.repr(ast)
+        expected = (
+            '{"conditional_1": {"isPositive_1": {"x": [-5]}, '
+            '"print_1": {"message": ["Positive"]}, '
+            '"print_2": {"message": ["Negative"]}}}'
+        )
+        self.assertEqual(result, expected)
 
 
 class TestToolMethod(unittest.IsolatedAsyncioTestCase):

--- a/treelang/ai/prompt.py
+++ b/treelang/ai/prompt.py
@@ -22,6 +22,18 @@ You are the AI Arborist because, given a set of useful functions you create beau
 5. This rule applies recursively to all nested function calls.
 6. If the AST contains nested function calls as parameters, preserve the inner call's order first, then integrate it in the parent call at the correct position.
 
+Additionally, the following Tree Node types are supported to enhance the expressivity of the AST:
+
+### Conditional
+
+Represents conditional logic (e.g., `if-else` statements).  
+**Example:**
+{
+  "type": "conditional",
+  "condition": {"type": "function", "name": "isPositive", "params": [{"type": "value", "name": "x", "value": -5}]},
+  "true_branch": {"type": "function", "name": "print", "params": [{"type": "value", "name": "message", "value": "Positive"}]},
+  "false_branch": {"type": "function", "name": "print", "params": [{"type": "value", "name": "message", "value": "Negative"}]}
+}
 
 Please think about your answer carefully and always double check your answer. Here are some examples:
 

--- a/treelang/ai/provider.py
+++ b/treelang/ai/provider.py
@@ -79,9 +79,9 @@ try:
     """
     Example of a non-MCP tool provider using LlamaIndex for tools provision.
     In order to use this, you need to install LlamaIndex and have it available in your environment:
-    
+
     `pip install llama-index`
-    
+
     """
     from llama_index.tools import FunctionTool
 
@@ -108,7 +108,7 @@ try:
                         }
                     )
                 self.tools = {tool["name"]: tool for tool in tools}
-                return tools    
+                return tools
             else:
                 return self.tools.values()
 

--- a/treelang/trees/tree.py
+++ b/treelang/trees/tree.py
@@ -129,10 +129,12 @@ class TreeConditional(TreeNode):
 
     async def eval(self, provider: ToolProvider) -> Any:
         condition_result = await self.condition.eval(provider)
+
         if condition_result:
             return await self.true_branch.eval(provider)
         elif self.false_branch:
             return await self.false_branch.eval(provider)
+
         return None
 
 
@@ -373,11 +375,17 @@ class AST:
                         props.pop()
 
                     properties = props[-1]
-
                     key = node.name
                     # be mindful of duplicate arguments names
                     if key in arg_names:
+                        # we add a random suffix to the key
                         key = key + f"_{random.randint(1, 1000)}"
+                        # rename the parameter in the properties dict
+                        properties = {
+                            key if k == node.name else k: v
+                            for k, v in properties.items()
+                        }
+                        node.name = key
                     arg_names.append(key)
                     param_objs.append(
                         Parameter(

--- a/treelang/trees/tree.py
+++ b/treelang/trees/tree.py
@@ -106,6 +106,36 @@ class TreeValue(TreeNode):
         return self.value
 
 
+class TreeConditional(TreeNode):
+    """
+    Represents a conditional statement in the AST.
+
+    Attributes:
+        condition (TreeNode): The condition to evaluate.
+        true_branch (TreeNode): The branch to execute if the condition is true.
+        false_branch (TreeNode): The branch to execute if the condition is false.
+
+    Methods:
+        eval(ToolProvider): Evaluates the condition and executes the appropriate branch.
+    """
+
+    def __init__(
+        self, condition: TreeNode, true_branch: TreeNode, false_branch: TreeNode = None
+    ) -> None:
+        super().__init__("conditional")
+        self.condition = condition
+        self.true_branch = true_branch
+        self.false_branch = false_branch
+
+    async def eval(self, provider: ToolProvider) -> Any:
+        condition_result = await self.condition.eval(provider)
+        if condition_result:
+            return await self.true_branch.eval(provider)
+        elif self.false_branch:
+            return await self.false_branch.eval(provider)
+        return None
+
+
 class AST:
     """
     Represents an Abstract Syntax Tree (AST) for a very simple programming language.
@@ -135,6 +165,12 @@ class AST:
             return TreeFunction(ast["name"], cls.parse(ast["params"]))
         if node_type == "value":
             return TreeValue(ast["name"], ast["value"])
+        if node_type == "conditional":
+            return TreeConditional(
+                cls.parse(ast["condition"]),
+                cls.parse(ast["true_branch"]),
+                cls.parse(ast.get("false_branch")),
+            )
 
         raise ValueError(f"unknown node type: {node_type}")
 
@@ -171,6 +207,12 @@ class AST:
                     statement, op
                 )  # Recursively visit each statement in the program
 
+        if isinstance(ast, TreeConditional):
+            cls.visit(ast.condition, op)
+            cls.visit(ast.true_branch, op)  # Recursively visit the true branch
+            if ast.false_branch:
+                cls.visit(ast.false_branch, op)  # Recursively visit the false branch
+
         elif isinstance(ast, TreeFunction):
             for param in ast.params:
                 cls.visit(param, op)  # Recursively visit each parameter of the function
@@ -197,6 +239,12 @@ class AST:
                 await cls.avisit(
                     statement, op
                 )  # Recursively visit each statement in the program
+
+        if isinstance(ast, TreeConditional):
+            await cls.avisit(ast.condition, op)
+            await cls.avisit(ast.true_branch, op)
+            if ast.false_branch:
+                await cls.avisit(ast.false_branch, op)
 
         elif isinstance(ast, TreeFunction):
             for param in ast.params:
@@ -247,6 +295,21 @@ class AST:
                 if isinstance(value, float) and value.is_integer():
                     value = int(value)
                 representation = representation.replace("%s", f'"{name}": [{value}]', 1)
+            if isinstance(node, TreeConditional):
+                name = "conditional"
+
+                if name not in name_counts:
+                    name_counts[name] = 0
+
+                name_counts[name] += 1
+                num_operands = 3 if node.false_branch else 2
+                args = "{" + ", ".join(["%s"] * num_operands) + "}"
+
+                representation = representation.replace(
+                    "%s",
+                    f'"{name}_{name_counts[name]}": {args}',
+                    1,
+                )
 
         cls.visit(ast, _f)
         return representation


### PR DESCRIPTION
## Purpose

Added  a `TreeConditional` node which adds the ability to have conditionals in the generated Abstract Syntax Trees.

## Tests

The `TreeNode` tests and `AST` tests have been updated with tests for the new `TreeConditional`

## Cookbook

The `calculator` cookbook now showcases a query that requires a conditional node.