### PR TITLE
selector to accept query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.7.3] - 2025-09-13
+
+### Added
+
+- Added `query` parameter to `BaseToolSelector.select()`.
+- `OpenAIArborist` now passes the query to its `selector`.
+
 ## [0.7.2] - 2025-08-08
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "treelang"
-version = "0.7.2"
+version = "0.7.3"
 description = "LLM function calling on steroids using Abstract Syntax Trees."
 authors = [
     {name = "csolar",email = "cristiano.solarino@brightminded.com"}

--- a/treelang/ai/arborist.py
+++ b/treelang/ai/arborist.py
@@ -292,7 +292,7 @@ class OpenAIArborist(BaseArborist):
         if self.supports_temperature(self.model):
             params["temperature"] = 0.0
 
-        available_tools = await self.selector.select(self.provider)
+        available_tools = await self.selector.select(self.provider, query)
 
         if available_tools:
             params["tools"] = [

--- a/treelang/ai/selector.py
+++ b/treelang/ai/selector.py
@@ -13,14 +13,15 @@ class BaseToolSelector:
 
     """
 
-    async def select(self, provider: ToolProvider, **kwargs) -> List[Any]:
+    async def select(self, provider: ToolProvider, query: str, **kwargs) -> List[Any]:
         """
         It selects a subset of all the available tools registered on the MCP server
         corresponding to the given session.
 
         Args:
             provider: ToolProvider object - a tool provider containing information on the available tools.
-
+            query: str - a query string to help the selector choose the right tools.
+            **kwargs: Additional keyword arguments.
         Returns:
             List of types.Tool objects - a list of selected tools.
         """
@@ -32,5 +33,5 @@ class AllToolsSelector(BaseToolSelector):
     The most basic Selector which just returns all tools available in the system.
     """
 
-    async def select(self, provider: ToolProvider, **kwargs) -> List[Any]:
+    async def select(self, provider: ToolProvider, query: str, **kwargs) -> List[Any]:
         return await provider.list_tools()


### PR DESCRIPTION
# Purpose

To make the selector more useful, we now pass in the user query as well so that it may be used as context for filtering tools, for example, if the selector is a Tool RAG retriever.